### PR TITLE
Bug Fixes

### DIFF
--- a/Session.cs
+++ b/Session.cs
@@ -36,7 +36,7 @@ namespace Wordle
 
                 if (IsGuessCorrect())
                 {
-                    if (i == 1)
+                    if (i == 5)
                     {
                         Console.WriteLine($"\nYou guessed the word in {MaxGuesses - i} guess!");
                     }

--- a/Session.cs
+++ b/Session.cs
@@ -125,6 +125,7 @@ namespace Wordle
         {
             Console.WriteLine();
 
+            int index = 0;
             foreach (char letter in Guess)
             {
                 if (!Word.Contains(letter))
@@ -133,7 +134,7 @@ namespace Wordle
                     Console.Write(letter);
                     Console.ResetColor();
                 }
-                else if (Word.IndexOf(letter) == Guess.IndexOf(letter))
+                else if (Word[index] == letter)
                 {
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.Write(letter);
@@ -145,6 +146,8 @@ namespace Wordle
                     Console.Write(letter);
                     Console.ResetColor();
                 }
+
+                ++index;
             }
 
             Console.WriteLine();

--- a/Session.cs
+++ b/Session.cs
@@ -32,7 +32,6 @@ namespace Wordle
 
                 PrintWord();
                 UpdateGuessedLetters();
-                PrintGameState();
 
                 if (IsGuessCorrect())
                 {
@@ -46,6 +45,8 @@ namespace Wordle
                     }
                     break;
                 }
+
+                PrintGameState();
 
                 if (i == 0)
                 {


### PR DESCRIPTION
Fixed guess count pluralization.
The game would incorrectly pluralize the word 'guess' in the end-game message.

Relocated game state printing method.
Relocated `PrintGameState()` in the execution flow so that it doesn't print after the game is one.

Refactored letter position checking in `PrintWord()` method.